### PR TITLE
Add Python version of webhook conversation

### DIFF
--- a/node/conversation-webhook/README.md
+++ b/node/conversation-webhook/README.md
@@ -46,6 +46,7 @@ PHONIC_API_KEY="your_api_key"
 PHONIC_WEBHOOK_SECRET="your_webhook_secret" // Found in the Webhooks tab in the Phonic UI
 PHONIC_CONFIG_WEBHOOK_AUTHORIZATION="Bearer your_auth_key"
 NGROK_URL="https://your-ngrok-url.ngrok.io" // Your server's public URL
+CUSTOMER_PHONE_NUMBER="+15551234567" // Phone number to call
 ```
 
 Copy the public URL (e.g., `https://abc123.ngrok.io`) and add it to your `.env.local` as `NGROK_URL`.
@@ -63,8 +64,6 @@ This starts a server with three endpoints:
 - `/webhooks/add-destination`: Custom webhook tool endpoint
 
 ## 5. Make an Outbound Call
-
-Update `YOUR_PHONE_NUMBER` in `outbound-call.ts`, then run:
 
 ```bash
 npm run conversation-webhook:outbound-call

--- a/node/conversation-webhook/create-agent.ts
+++ b/node/conversation-webhook/create-agent.ts
@@ -13,7 +13,7 @@ const client = new PhonicClient({ apiKey });
 async function createTool() {
   await client.tools.create({
     name: "add_destination",
-    description: "Get the weather for a city",
+    description: "Add a destination to the list when the user indicates they will visit it.",
     type: "custom_webhook",
     execution_mode: "sync",
     endpoint_method: "POST",

--- a/node/conversation-webhook/outbound-call.ts
+++ b/node/conversation-webhook/outbound-call.ts
@@ -9,7 +9,7 @@ const client = new PhonicClient({
 
 async function outboundCall() {
   await client.conversations.outboundCall({
-    to_phone_number: "YOUR_PHONE_NUMBER", // e.g. +15551234567
+    to_phone_number: process.env.CUSTOMER_PHONE_NUMBER as string,
     config: {
       agent: "travel-agent",
       template_variables: {

--- a/node/quick-start/README.md
+++ b/node/quick-start/README.md
@@ -25,6 +25,7 @@ npm install
 
 ```dotenv
 PHONIC_API_KEY="your_api_key"
+CUSTOMER_PHONE_NUMBER="+15551234567" # Phone number to call
 ```
 
 ### 3. Create an agent
@@ -34,8 +35,6 @@ npm run quick-start:create-agent
 ```
 
 ### 4. Make an outbound call
-
-Open `outbound-call.ts`, update `YOUR_PHONE_NUMBER` to your phone number, and run:
 
 ```bash
 npm run quick-start:outbound-call

--- a/node/quick-start/outbound-call.ts
+++ b/node/quick-start/outbound-call.ts
@@ -9,7 +9,7 @@ const client = new PhonicClient({
 
 async function outboundCall() {
   await client.conversations.outboundCall({
-    to_phone_number: "YOUR_PHONE_NUMBER", // e.g. +15551234567
+    to_phone_number: process.env.CUSTOMER_PHONE_NUMBER as string,
     config: {
       agent: "my-first-agent",
     },

--- a/python/README.md
+++ b/python/README.md
@@ -18,4 +18,5 @@ To configure your environment, follow these steps:
 2. Create an `.env.local` file in this directory (`phonic-examples/python`) with the following content:
 ```dotenv
 PHONIC_API_KEY="your_api_key"
+CUSTOMER_PHONE_NUMBER="+15551234567" # Phone number for outbound calls
 ```

--- a/python/conversation-webhook/README.md
+++ b/python/conversation-webhook/README.md
@@ -53,6 +53,7 @@ PHONIC_API_KEY="your_api_key"
 PHONIC_WEBHOOK_SECRET="your_webhook_secret" # Found in the Webhooks tab in the Phonic UI
 PHONIC_CONFIG_WEBHOOK_AUTHORIZATION="Bearer your_auth_key"
 NGROK_URL="https://your-ngrok-url.ngrok.io" # Your server's public URL
+CUSTOMER_PHONE_NUMBER="+15551234567" # Phone number to call
 ```
 
 Copy the public URL (e.g., `https://abc123.ngrok.io`) and add it to your `.env.local` as `NGROK_URL`.

--- a/python/conversation-webhook/README.md
+++ b/python/conversation-webhook/README.md
@@ -1,0 +1,86 @@
+# Conversation Webhook Example (Python)
+
+This example demonstrates how to create a Phonic agent that uses:
+
+- **Webhook Configs**: Calls your local server endpoint to get a dynamic config
+- **Custom Webhook Tools**: Tool execution via webhooks  
+- **Event Webhooks**: Sends conversation events to your local server
+
+The agent that you will create will hit the `/webhooks/phonic-config` endpoint to override it's default configuration. When you make an outbound call and confirm that you will visit a destination, your server will be called via the `/webhooks/add-destination` endpoint. After the conclusion of the call, your server will receive a conversation.ended and a conversation.analysis webhook.
+
+## 1. Prerequisites
+
+- Python 3.11+ installed
+- [Phonic](https://phonic.co) API key for voice processing
+- [ngrok](https://ngrok.com) for exposing your local server to the internet
+
+## 2. Setup
+
+### 2.1 Install Dependencies
+
+Navigate to the Python examples directory:
+
+```bash
+cd phonic-examples/python
+```
+
+Install dependencies using uv:
+
+```bash
+uv sync
+```
+
+Install and run ngrok to expose port 3000:
+
+```bash
+npm install -g ngrok
+ngrok http 3000
+```
+
+### 2.2 Enable Webhook Events
+
+Enable webhook events in the Phonic UI. Navigate to the [Webhooks](https://phonic.co/webhooks) page and click on the "Create Webhook" button, subscribing to the following events:
+
+- conversation.analysis
+- conversation.ended
+
+### 2.3 Configure Environment
+
+Create an `.env.local` file in the examples root (`phonic-examples/python/.env.local`) with:
+
+```dotenv
+PHONIC_API_KEY="your_api_key"
+PHONIC_WEBHOOK_SECRET="your_webhook_secret" # Found in the Webhooks tab in the Phonic UI
+PHONIC_CONFIG_WEBHOOK_AUTHORIZATION="Bearer your_auth_key"
+NGROK_URL="https://your-ngrok-url.ngrok.io" # Your server's public URL
+```
+
+Copy the public URL (e.g., `https://abc123.ngrok.io`) and add it to your `.env.local` as `NGROK_URL`.
+
+## 3. Create the Agent
+
+First, create the Phonic agent and tool:
+
+```bash
+uv run python conversation-webhook/create_agent.py
+```
+
+This creates an agent with a custom webhook tool that will call your server.
+
+## 4. Start the Webhook Server
+
+```bash
+uv run python conversation-webhook/server.py
+```
+
+This starts a FastAPI server with three endpoints:
+
+- `/webhooks/phonic-config`: Configuration endpoint for dynamic agent configuration
+- `/webhooks/events`: Receives conversation webhook events from Phonic
+- `/webhooks/add-destination`: Custom webhook tool endpoint
+
+## 5. Make an Outbound Call
+
+```bash
+uv run python conversation-webhook/outbound_call.py
+```

--- a/python/conversation-webhook/create_agent.py
+++ b/python/conversation-webhook/create_agent.py
@@ -17,7 +17,7 @@ client = Phonic(api_key=os.getenv("PHONIC_API_KEY"))
 def create_tool():
     client.tools.create(
         name="add_destination",
-        description="Get the weather for a city",
+        description="Add a destination to the list when the user indicates they will visit it.",
         type="custom_webhook",
         execution_mode="sync",
         endpoint_method="POST",

--- a/python/conversation-webhook/create_agent.py
+++ b/python/conversation-webhook/create_agent.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from phonic import Phonic
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env.local")
+
+CONFIG_WEBHOOK_AUTHORIZATION = os.getenv(
+    "PHONIC_CONFIG_WEBHOOK_AUTHORIZATION", "Bearer authorization_key"
+)
+NGROK_URL = os.getenv("NGROK_URL")
+
+client = Phonic(api_key=os.getenv("PHONIC_API_KEY"))
+
+
+def create_tool():
+    client.tools.create(
+        name="add_destination",
+        description="Get the weather for a city",
+        type="custom_webhook",
+        execution_mode="sync",
+        endpoint_method="POST",
+        endpoint_url=f"{NGROK_URL}/webhooks/add-destination",
+        endpoint_timeout_ms=7000,
+        parameters=[
+            {
+                "name": "destination_name",
+                "description": "The name of the destination",
+                "is_required": True,
+                "type": "string",
+            }
+        ],
+    )
+
+
+def create_agent():
+    create_tool()
+    client.agents.create(
+        name="travel-agent",
+        phone_number="assign-automatically",
+        timezone="America/Los_Angeles",
+        tools=["add_destination"],
+        template_variables={
+            "customer_name": {"default_value": "John"},
+            "interest": {"default_value": "biking"},
+        },
+        welcome_message="Hi {{customer_name}}. How can I help you today?",
+        system_prompt="You are an expert in San Francisco, helping users understand where best to visit. Convince the customer to visit the Golden Gate Bridge. The customer's name is {{customer_name}}. The current time is {{system_time}}. The user interested in {{interest}}. After the user says they will visit the destination, add it to the list of destinations.",
+        configuration_endpoint={
+            "url": f"{NGROK_URL}/webhooks/phonic-config",
+            "headers": {"Authorization": CONFIG_WEBHOOK_AUTHORIZATION},
+            "timeout_ms": 7000,
+        },
+    )
+
+
+if __name__ == "__main__":
+    create_agent()

--- a/python/conversation-webhook/create_agent.py
+++ b/python/conversation-webhook/create_agent.py
@@ -46,7 +46,13 @@ def create_agent():
             "interest": {"default_value": "biking"},
         },
         welcome_message="Hi {{customer_name}}. How can I help you today?",
-        system_prompt="You are an expert in San Francisco, helping users understand where best to visit. Convince the customer to visit the Golden Gate Bridge. The customer's name is {{customer_name}}. The current time is {{system_time}}. The user interested in {{interest}}. After the user says they will visit the destination, add it to the list of destinations.",
+        system_prompt=(
+            "You are an expert in San Francisco, helping users understand where best to visit. "
+            "Convince the customer to visit the Golden Gate Bridge. The customer's name is "
+            "{{customer_name}}. The current time is {{system_time}}. The user interested in "
+            "{{interest}}. After the user says they will visit the destination, add it to the "
+            "list of destinations."
+        ),
         configuration_endpoint={
             "url": f"{NGROK_URL}/webhooks/phonic-config",
             "headers": {"Authorization": CONFIG_WEBHOOK_AUTHORIZATION},

--- a/python/conversation-webhook/outbound_call.py
+++ b/python/conversation-webhook/outbound_call.py
@@ -11,7 +11,7 @@ client = Phonic(api_key=os.getenv("PHONIC_API_KEY"))
 
 def outbound_call():
     client.conversations.outbound_call(
-        to_phone_number="+16466239678",  # e.g. +15551234567
+        to_phone_number=os.getenv("CUSTOMER_PHONE_NUMBER", ""),
         config={
             "agent": "travel-agent",
             "template_variables": {

--- a/python/conversation-webhook/outbound_call.py
+++ b/python/conversation-webhook/outbound_call.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from phonic import Phonic
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env.local")
+
+client = Phonic(api_key=os.getenv("PHONIC_API_KEY"))
+
+
+def outbound_call():
+    client.conversations.outbound_call(
+        to_phone_number="+16466239678",  # e.g. +15551234567
+        config={
+            "agent": "travel-agent",
+            "template_variables": {
+                "customer_name": "Alice",
+                "interest": "nature",
+            },
+        },
+    )
+
+
+if __name__ == "__main__":
+    outbound_call()

--- a/python/conversation-webhook/server.py
+++ b/python/conversation-webhook/server.py
@@ -1,0 +1,88 @@
+import os
+import uvicorn
+from pathlib import Path
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi.responses import JSONResponse
+from svix.webhooks import Webhook
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env.local")
+
+app = FastAPI()
+
+config_webhook_authorization = os.getenv(
+    "PHONIC_CONFIG_WEBHOOK_AUTHORIZATION", "Bearer authorization_key"
+)
+phonic_webhook_secret = os.getenv("PHONIC_WEBHOOK_SECRET")
+
+
+@app.post("/webhooks/phonic-config")
+async def phonic_config(request: Request) -> JSONResponse:
+    if request.headers.get("Authorization") != config_webhook_authorization:
+        raise HTTPException(status_code=400, detail="Bad Request")
+    
+    body = await request.json()
+    print(body)
+    agent = body["agent"]
+    agent_default_system_prompt = agent["system_prompt"]
+    
+    response = {
+        "welcome_message": "Hey {{customer_name}}, how can I help you today?",
+        "system_prompt": f"{agent_default_system_prompt} The customer is visiting 1 week from now.",
+        "template_variables": {
+            "customer_name": "Alice",
+            "interest": "nature"
+        }
+    }
+    
+    return JSONResponse(content=response)
+
+
+@app.post("/webhooks/events")
+async def events_webhook(request: Request) -> Response:
+    if not phonic_webhook_secret:
+        raise HTTPException(status_code=400, detail="Bad Request")
+    
+    raw_body = await request.body()
+    
+    print("Events webhook raw body:", raw_body.decode())
+    
+    signature = request.headers.get("svix-signature", "")
+    svix_id = request.headers.get("svix-id", "")
+    svix_timestamp = request.headers.get("svix-timestamp", "")
+    
+    try:
+        wh = Webhook(phonic_webhook_secret)
+        headers = {
+            "svix-signature": signature,
+            "svix-id": svix_id,
+            "svix-timestamp": svix_timestamp,
+        }
+        payload = wh.verify(raw_body, headers)
+        print("Events webhook payload:", payload)
+        
+        return Response(content="OK", status_code=200)
+    except Exception as error:
+        print("Failed to verify webhook:", error)
+        raise HTTPException(status_code=400, detail="Bad Request")
+
+
+@app.post("/webhooks/add-destination")
+async def add_destination(request: Request) -> JSONResponse:
+    destination_name = request.query_params.get("destination_name")
+    
+    print("add-destination webhook tool called for destination:", destination_name)
+    
+    response = {
+        "success": True,
+        "message": f"Destination {destination_name} added to the list of destinations"
+    }
+    
+    return JSONResponse(content=response)
+
+
+if __name__ == "__main__":
+    port = 3000
+    print(f"Listening on port {port}")
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/python/conversation-webhook/server.py
+++ b/python/conversation-webhook/server.py
@@ -46,8 +46,6 @@ async def events_webhook(request: Request) -> Response:
     
     raw_body = await request.body()
     
-    print("Events webhook raw body:", raw_body.decode())
-    
     signature = request.headers.get("svix-signature", "")
     svix_id = request.headers.get("svix-id", "")
     svix_timestamp = request.headers.get("svix-timestamp", "")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,5 +11,7 @@ dependencies = [
     "isort==6.0.1",
     "phonic==0.30.7",
     "python-dotenv==1.1.1",
+    "svix==1.76.1",
     "twilio==9.8.1",
+    "uvicorn==0.32.0",
 ]

--- a/python/quick-start/README.md
+++ b/python/quick-start/README.md
@@ -16,8 +16,6 @@ python create_agent.py
 
 ### 2. Make an outbound call
 
-Open `outbound_call.py`, update `YOUR_PHONE_NUMBER` to your phone number, and run:
-
 ```bash
 python outbound_call.py
 ```

--- a/python/quick-start/outbound_call.py
+++ b/python/quick-start/outbound_call.py
@@ -10,7 +10,7 @@ client = Phonic(
 )
 
 client.conversations.outbound_call(
-    to_phone_number="YOUR_PHONE_NUMBER",  # e.g. +15551234567
+    to_phone_number=os.getenv("CUSTOMER_PHONE_NUMBER", "") # e.g. +15551234567
     config={
         "agent": "my-first-agent",
         "welcome_message": "Hello, how can I help you?",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -249,6 +249,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998 },
+]
+
+[[package]]
 name = "fast-flights"
 version = "2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -543,7 +555,9 @@ dependencies = [
     { name = "isort" },
     { name = "phonic" },
     { name = "python-dotenv" },
+    { name = "svix" },
     { name = "twilio" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -554,7 +568,9 @@ requires-dist = [
     { name = "isort", specifier = "==6.0.1" },
     { name = "phonic", specifier = "==0.30.7" },
     { name = "python-dotenv", specifier = "==1.1.1" },
+    { name = "svix", specifier = "==1.76.1" },
     { name = "twilio", specifier = "==9.8.1" },
+    { name = "uvicorn", specifier = "==0.32.0" },
 ]
 
 [[package]]
@@ -759,6 +775,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -835,6 +863,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +894,24 @@ wheels = [
 ]
 
 [[package]]
+name = "svix"
+version = "1.76.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/b6/4f2ef591a853ad8401359e8403da947127e95f46c20193434315a2b68e7e/svix-1.76.1.tar.gz", hash = "sha256:1d46e4031edd350a7b2e27ccd89049b0e45cc78ec096cc3b6896cfa87abe2f18", size = 48129 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/ac/02dda2a6f70b20de6510c66b0b853ceb9cafc1f8433fc1dcab25e6550105/svix-1.76.1-py3-none-any.whl", hash = "sha256:1f6174849196ccb5fd8c41d7e30d11184ab14ebef57765d7db1d2ab1cf22c28a", size = 100464 },
+]
+
+[[package]]
 name = "twilio"
 version = "9.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -869,6 +924,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/44/7220104ed67c1a2a99bf30ef79f658703bd17e3341601c844669fe7a0072/twilio-9.8.1.tar.gz", hash = "sha256:e1feeeeb5f12e59fa4788a1e5b9338cf521480dbb8352e5620b8f92493c2206d", size = 932464 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/80/25dfcec263c47d6d04de0436bcc2064bcaaecfa05f65abad879e54e583c4/twilio-9.8.1-py2.py3-none-any.whl", hash = "sha256:764ccb00a6cd9cdf0217468e7a446cd3aa5df418981aaff8c5b54be9d89f13f2", size = 1820821 },
+]
+
+[[package]]
+name = "types-deprecated"
+version = "1.2.15.20250304"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/67/eeefaaabb03b288aad85483d410452c8bbcbf8b2bd876b0e467ebd97415b/types_deprecated-1.2.15.20250304.tar.gz", hash = "sha256:c329030553029de5cc6cb30f269c11f4e00e598c4241290179f63cda7d33f719", size = 8015 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/e3/c18aa72ab84e0bc127a3a94e93be1a6ac2cb281371d3a45376ab7cfdd31c/types_deprecated-1.2.15.20250304-py3-none-any.whl", hash = "sha256:86a65aa550ea8acf49f27e226b8953288cd851de887970fbbdf2239c116c3107", size = 8553 },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/0a/775f8551665992204c756be326f3575abba58c4a3a52eef9909ef4536428/types_python_dateutil-2.9.0.20250822.tar.gz", hash = "sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53", size = 16084 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/d9/a29dfa84363e88b053bf85a8b7f212a04f0d7343a4d24933baa45c06e08b/types_python_dateutil-2.9.0.20250822-py3-none-any.whl", hash = "sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc", size = 17892 },
 ]
 
 [[package]]
@@ -899,6 +972,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/fc/1d785078eefd6945f3e5bab5c076e4230698046231eb0f3747bc5c8fa992/uvicorn-0.32.0.tar.gz", hash = "sha256:f78b36b143c16f54ccdb8190d0a26b5f1901fe5a3c777e1ab29f26391af8551e", size = 77564 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/14/78bd0e95dd2444b6caacbca2b730671d4295ccb628ef58b81bee903629df/uvicorn-0.32.0-py3-none-any.whl", hash = "sha256:60b8f3a5ac027dcd31448f411ced12b5ef452c646f76f02f8cc3f25d8d26fd82", size = 63723 },
 ]
 
 [[package]]
@@ -941,6 +1027,65 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482 },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674 },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959 },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376 },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604 },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782 },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076 },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457 },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745 },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806 },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998 },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020 },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098 },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036 },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156 },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102 },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732 },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705 },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877 },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885 },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003 },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025 },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108 },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072 },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214 },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105 },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766 },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711 },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885 },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896 },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132 },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091 },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172 },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163 },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963 },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945 },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857 },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178 },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310 },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266 },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544 },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283 },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366 },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571 },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094 },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659 },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946 },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717 },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334 },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471 },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591 },
 ]
 
 [[package]]


### PR DESCRIPTION
Make fastapi server:
- has config endpoint
- event webhooks endpoint
- webhook tool endpoint

script to create tool and agent.

Agent:
- Hit config endpoint
- Tool hits webhook endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Python conversation webhook example with a FastAPI server offering config, event, and custom tool endpoints; includes an outbound-call flow and agent/tool creation utilities.
  * Updated tool wording to clarify "Add a destination" behavior.

* **Documentation**
  * Added a comprehensive README covering prerequisites, setup, environment configuration, running the server, creating the agent, and end-to-end flow.

* **Chores**
  * Added dependencies for webhook verification and an ASGI server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->