### PR TITLE
Fix up the Quick-start READMEs

### DIFF
--- a/quick-start/node/README.md
+++ b/quick-start/node/README.md
@@ -1,8 +1,7 @@
-
 # Quick Start example
 
 This example walks you through creating a simple agent and making both outbound and inbound calls.
-It complements the [Quick Start guide](https://docs.phonic.co/guides/quick_start).
+It complements the [Quick Start guide](https://docs.phonic.co/docs/get-started/quick-start).
 
 ## 📋 Prerequisites
 
@@ -14,12 +13,14 @@ cd phonic-examples/quick-start/node
 npm install
 ```
 
-To set up your Phonic credentials:
+To set up your environment variables:
 1. Obtain a Phonic API Key by visiting the [Phonic API Keys](https://phonic.co/api-keys) page and creating an API key.
 2. Create an `.env.local` file with the following content:
 ```dotenv
 PHONIC_API_KEY="your_api_key"
+CUSTOMER_PHONE_NUMBER="your_phone_number"  // e.g., +15551234567
 ```
+Your phone number must include the leading `+` and country code, and must not contain dashes or spaces.
 
 ## 🚀 Run steps
 
@@ -31,7 +32,6 @@ npm run create-agent
 
 ### 2. Make an outbound call
 
-Replace `CUSTOMER_PHONE_NUMBER` with your phone number in `outound_call.py`, and then run:
 ```bash
 npm run outbound-call
 ```

--- a/quick-start/python/README.md
+++ b/quick-start/python/README.md
@@ -1,7 +1,7 @@
 # Quick Start example
 
 This example walks you through creating a simple agent and making both outbound and inbound calls.
-It complements the [Quick Start guide](https://docs.phonic.co/guides/quick_start).
+It complements the [Quick Start guide](https://docs.phonic.co/docs/get-started/quick-start).
 
 ## 📋 Prerequisites
 
@@ -13,12 +13,14 @@ cd phonic-examples/quick-start/python
 uv sync --all-extras
 ```
 
-To set up your Phonic credentials:
+To set up your environment variables:
 1. Obtain a Phonic API Key by visiting the [Phonic API Keys](https://phonic.co/api-keys) page and creating an API key.
 2. Create an `.env.local` file with the following content:
 ```dotenv
 PHONIC_API_KEY="your_api_key"
+CUSTOMER_PHONE_NUMBER="your_phone_number"  // e.g., +15551234567
 ```
+Your phone number must include the leading `+` and country code, and must not contain dashes or spaces.
 
 ## 🚀 Run Steps
 
@@ -30,7 +32,6 @@ uv run create_agent.py
 
 ### 2. Make an outbound call
 
-Replace `CUSTOMER_PHONE_NUMBER` with your phone number in `outound_call.py`, and then run:
 ```bash
 uv run outbound_call.py
 ```

--- a/quick-start/python/create_agent.py
+++ b/quick-start/python/create_agent.py
@@ -9,7 +9,13 @@ client = Phonic(
     api_key=os.getenv("PHONIC_API_KEY"),
 )
 
-client.agents.create(
-    name="my-first-agent",
-    phone_number="assign-automatically",
-)
+
+def create_agent():
+    client.agents.create(
+        name="my-first-agent",
+        phone_number="assign-automatically",
+    )
+
+
+if __name__ == "__main__":
+    create_agent()

--- a/quick-start/python/outbound_call.py
+++ b/quick-start/python/outbound_call.py
@@ -9,10 +9,16 @@ client = Phonic(
     api_key=os.getenv("PHONIC_API_KEY"),
 )
 
-client.conversations.outbound_call(
-    to_phone_number=os.getenv("CUSTOMER_PHONE_NUMBER", "") # e.g. +15551234567
-    config={
-        "agent": "my-first-agent",
-        "welcome_message": "Hello, how can I help you?",
-    },
-)
+
+def outbound_call():
+    client.conversations.outbound_call(
+        to_phone_number=os.getenv("CUSTOMER_PHONE_NUMBER"),
+        config={
+            "agent": "my-first-agent",
+            "welcome_message": "Hello, how can I help you?",
+        },
+    )
+
+
+if __name__ == "__main__":
+    outbound_call()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified Quick Start outbound call flow: run npm run outbound-call (no manual placeholder edits).
- Documentation
  - Updated Quick Start links to the new URL.
  - Clarified environment variables setup and phone number format (+country code, no dashes/spaces).
  - Added example CUSTOMER_PHONE_NUMBER in guides.
- Refactor
  - Improved Python Quick Start scripts with function wrappers and standard entry points for clearer, direct execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->