### PR TITLE
Doc clarifications + Python teardown fix

### DIFF
--- a/05-telnyx-media-streaming/node/README.md
+++ b/05-telnyx-media-streaming/node/README.md
@@ -80,19 +80,23 @@ spaces.
 Telnyx starts a media stream from either a TeXML application or a Voice API
 (Call Control) application. Pick whichever your number is already on.
 
-### Option A — TeXML application (drives the inbound flow here)
+### Option A — TeXML application (inbound)
 
-1. In the Telnyx portal, create a **TeXML Application**.
+1. In the Telnyx portal, go to Voice Suite > Programmable Voice > create a **TeXML Application**.
 2. Set its **Voice Method** webhook (inbound) to `{NGROK_URL}/inbound` (GET or
    POST — the endpoint accepts both).
-3. Assign your phone number to this application.
+3. Assign your phone number to this application by going to Voice Suite > 
+Verified Numbers so that your agent can pick up your call.
 
 ### Option B — Voice API / Call Control application (outbound)
 
 For `outbound-call.ts` you need a **Voice API application** (its id is
 `TELNYX_CONNECTION_ID`), and `TELNYX_PHONE_NUMBER` must be able to place calls
-on it. You do **not** need to configure the app's webhook in the portal — the
-dial request sets a per-call `webhook_url` pointing at `/call-control`.
+on it.
+
+1. In the Telnyx portal, go to Voice Suite > Programmable Voice > create a **Voice API Application**.
+2. Although it requires a webhook URL, `outbound-call.ts` will send a per-call `webhook_url` that overrides whatever is on the app. To match the code, you can enter `{NGROK_URL}/call-control`, or `https://example.com` will work fine as well.
+3. Telnyx blocks outbound calls on a connection that has no Outbound Voice Profile (OVP).  Create OVP in Voice Suite > Outbound Voice, make sure its allowed/whitelisted destinations include the country you're dialing (US/CA by default), and attach it to the application.
 
 The flow: dial (`outbound-call.ts`) → Telnyx posts `call.answered` to
 `/call-control` → the server issues `streaming_start` with
@@ -176,9 +180,7 @@ calling `sendConfig()` immediately throws. Send the config from the socket's
   the ngrok port must match the server `PORT`. Confirm with
   `curl -i https://<ngrok>/inbound` — you should get the `<Response>` XML, not
   an ngrok warning page.
-- **Trial account restrictions.** Telnyx trials only allow calls to/from
-  **verified** numbers. Verify your phone (or leave trial) or you'll get a
-  fast-busy before any webhook fires.
+- **Account is not funded.** You will need to fund your account before the app can receive/place calls. Go to Account > Manage Billing to view your account balance.
 - **Number not on the right connection.** The number must be assigned to your
   **TeXML application**, not a SIP connection.
 

--- a/05-telnyx-media-streaming/node/server.ts
+++ b/05-telnyx-media-streaming/node/server.ts
@@ -115,7 +115,8 @@ app.get(
 
           phonicSocket.on("close", (event) => {
             console.log(
-              `Phonic WebSocket closed with code ${event.code} and reason "${event.reason}"`,
+              `Phonic WebSocket closed with code ${event.code}` +
+                (event.reason ? ` and reason "${event.reason}"` : ""),
             );
           });
 

--- a/05-telnyx-media-streaming/python/README.md
+++ b/05-telnyx-media-streaming/python/README.md
@@ -74,19 +74,23 @@ spaces.
 Telnyx starts a media stream from either a TeXML application or a Voice API
 (Call Control) application. Pick whichever your number is already on.
 
-### Option A — TeXML application (drives the inbound flow here)
+### Option A — TeXML application (inbound)
 
-1. In the Telnyx portal, create a **TeXML Application**.
+1. In the Telnyx portal, go to Voice Suite > Programmable Voice > create a **TeXML Application**.
 2. Set its **Voice Method** webhook (inbound) to `{NGROK_URL}/inbound` (GET or
    POST — the endpoint accepts both).
-3. Assign your phone number to this application.
+3. Assign your phone number to this application by going to Voice Suite > 
+Verified Numbers so that your agent can pick up your call.
 
 ### Option B — Voice API / Call Control application (outbound)
 
 For `outbound_call.py` you need a **Voice API application** (its id is
 `TELNYX_CONNECTION_ID`), and `TELNYX_PHONE_NUMBER` must be able to place calls
-on it. You do **not** need to configure the app's webhook in the portal — the
-dial request sets a per-call `webhook_url` pointing at `/call-control`.
+on it.
+
+1. In the Telnyx portal, go to Voice Suite > Programmable Voice > create a **Voice API Application**.
+2. Although it requires a webhook URL, `outbound_call.py` will send a per-call `webhook_url` that overrides whatever is on the app. To match the code, you can enter `{NGROK_URL}/call-control`, or `https://example.com` will work fine as well.
+3. Telnyx blocks outbound calls on a connection that has no Outbound Voice Profile (OVP).  Create OVP in Voice Suite > Outbound Voice, make sure its allowed/whitelisted destinations include the country you're dialing (US/CA by default), and attach it to the application.
 
 The flow: dial (`outbound_call.py`) → Telnyx posts `call.answered` to
 `/call-control` → the server issues `streaming_start` with
@@ -159,8 +163,7 @@ silent, one-way, or dead audio. If you copied a Twilio bridge, check these:
   every restart; the TeXML app's webhook must point at the *current* URL, and
   the ngrok port must match the server `PORT`. Confirm with
   `curl -i https://<ngrok>/inbound` — you should get the `<Response>` XML.
-- **Trial account restrictions.** Telnyx trials only allow calls to/from
-  **verified** numbers, or you get a fast-busy before any webhook fires.
+- **Account is not funded.** You will need to fund your account before the app can receive/place calls. Go to Account > Manage Billing to view your account balance.
 - **Number not on the right connection.** The number must be assigned to your
   **TeXML application**, not a SIP connection.
 

--- a/05-telnyx-media-streaming/python/server.py
+++ b/05-telnyx-media-streaming/python/server.py
@@ -5,7 +5,7 @@ import os
 import httpx
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import FastAPI, Request, Response, WebSocket
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from phonic import AsyncPhonic, AudioChunkPayload
 from phonic.conversations.socket_client import ConversationsSocketClientResponse
 from phonic.types.config_payload import ConfigPayload
@@ -77,9 +77,14 @@ async def websocket_endpoint(websocket: WebSocket):
                 # conversation_created on it — that message can arrive first.
                 if stream_id is not None:
                     # Telnyx frame: event + media.payload only, no stream id.
-                    await websocket.send_json(
-                        {"event": "media", "media": {"payload": message.audio}}
-                    )
+                    try:
+                        await websocket.send_json(
+                            {"event": "media", "media": {"payload": message.audio}}
+                        )
+                    except (WebSocketDisconnect, RuntimeError):
+                        # Caller hung up; a Phonic frame can still arrive mid-
+                        # teardown and race the closed Telnyx socket. Ignore it.
+                        pass
             case "conversation_created":
                 conversation_created.set()
             case "error":


### PR DESCRIPTION
- README (node+python): rewrite Telnyx setup Option A/B as portal steps; document required webhook-URL field + Outbound Voice Profile for outbound; add account-funding troubleshooting note
- python/server.py: guard send_json against WebSocketDisconnect so a late Phonic frame during hangup no longer throws an unretrieved task exception
- node/server.ts: only log the Phonic close reason when one is present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-server logging/teardown hardening only; no auth, billing, or production API behavior changes.
> 
> **Overview**
> **Telnyx setup docs** (Node and Python READMEs) are expanded with portal navigation for TeXML and Voice API apps, number assignment via Verified Numbers, outbound webhook URL behavior, and **Outbound Voice Profile** requirements. Fast-busy troubleshooting now calls out **account funding** instead of trial-only verified-number limits.
> 
> **Python bridge** wraps `send_json` to Telnyx in a try/except for `WebSocketDisconnect` and `RuntimeError`, so a late Phonic audio frame after the caller hangs up no longer surfaces as an unhandled task exception.
> 
> **Node server** only appends the Phonic WebSocket close **reason** to logs when one is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62bd7417980453ad3e414ea7b17e7e381d349990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Telnyx setup instructions for inbound and outbound calling.
  * Added guidance for phone-number assignment, outbound voice profiles, destination whitelisting, per-call webhooks, and account funding.
  * Improved troubleshooting steps for calls that fail or do not reach the server.

* **Bug Fixes**
  * Improved WebSocket disconnect handling to prevent errors during connection shutdown.
  * Clarified connection-close logs by showing a reason only when one is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->