### PR TITLE
Mint a conversation-scoped session token in the browser example (PHO-3061)

### DIFF
--- a/06-conversation-browser/node/README.md
+++ b/06-conversation-browser/node/README.md
@@ -25,3 +25,27 @@ out of browser code.
 The HLS playlist and each segment are authenticated through the local proxy.
 The session token is intentionally short-lived and appears in proxied HLS URLs;
 the permanent API key is never sent to the browser.
+
+## Before you copy this into production
+
+The token is minted with `conversation_ids`, so it covers only the conversation
+it was requested for.
+
+Two things this example does not do, which you must:
+
+1. **Authorize the request.** `POST /session-token` here mints a token for any
+   caller. Confirm from your own session that the conversation belongs to the
+   person asking before creating the token — Phonic enforces *which*
+   conversation a token may read, not *whose* it is.
+2. **Keep the token off the browser if you can.** This example hands it to the
+   page so the browser can open the live WebSocket directly. Since the local
+   server already proxies the HLS requests, a stricter version attaches the
+   token server-side and proxies the WebSocket too, so the browser never holds
+   a Phonic credential at all.
+
+Session tokens receive a reduced payload on the live WebSocket. It carries only
+`id`, `external_id`, `origin`, `agent`, `items`, `text`, `summary`,
+`duration_ms`, `started_at`, `ended_at`,
+`assistant_end_conversation_signal_at` and `is_live` — every other field of the
+conversation is absent, not null. Access tokens and API keys still receive the
+full object.

--- a/06-conversation-browser/node/browser-live-preview.html
+++ b/06-conversation-browser/node/browser-live-preview.html
@@ -43,8 +43,16 @@
         status.textContent = "Creating a short-lived session...";
         const conversationId = input.value.trim();
         transcript.textContent = "";
-        const response = await fetch("/session-token", { method: "POST" });
-        if (!response.ok) throw new Error(await response.text());
+        const response = await fetch("/session-token", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ conversation_id: conversationId }),
+        });
+        if (!response.ok) {
+          const { error } = await response.json().catch(() => ({}));
+          status.textContent = error?.message ?? "Could not start the preview.";
+          return;
+        }
         const { session_token: token, api_url: apiUrl } = await response.json();
         const wsUrl = new URL(`${apiUrl}/conversations/${encodeURIComponent(conversationId)}/live/ws`);
         wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";

--- a/06-conversation-browser/node/browser-live-preview.ts
+++ b/06-conversation-browser/node/browser-live-preview.ts
@@ -22,7 +22,27 @@ app.get("/hls.js", (c) => {
 });
 
 app.post("/session-token", async (c) => {
-  const token = await client.auth.createSessionToken({ ttl_seconds: 300 });
+  const body = await c.req
+    .json<{ conversation_id?: string }>()
+    .catch((): { conversation_id?: string } => ({}));
+  const conversationId = body.conversation_id;
+
+  if (typeof conversationId !== "string" || conversationId === "") {
+    // Same error shape the Phonic API itself returns.
+    return c.json({ error: { message: "conversation_id is required" } }, 400);
+  }
+
+  // Your authorization belongs here. Phonic enforces which conversation a token
+  // may read; confirm the conversation belongs to the person asking before
+  // creating the token.
+
+  const token = await client.auth.createSessionToken({
+    ttl_seconds: 300,
+    // Restricts the token to this one conversation. Always set this when the
+    // token will be used from a browser.
+    conversation_ids: [conversationId],
+  });
+
   return c.json({ ...token, api_url: apiUrl });
 });
 

--- a/06-conversation-browser/node/package-lock.json
+++ b/06-conversation-browser/node/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "16.5.0",
         "hls.js": "1.6.18",
         "hono": "4.8.5",
-        "phonic": "0.32.9",
+        "phonic": "0.32.17",
         "tsx": "4.20.3"
       },
       "devDependencies": {
@@ -717,9 +717,9 @@
       }
     },
     "node_modules/phonic": {
-      "version": "0.32.9",
-      "resolved": "https://registry.npmjs.org/phonic/-/phonic-0.32.9.tgz",
-      "integrity": "sha512-eYY7CY9PULChjxxs0xqS7qawDksu2tq4vW9raWC+gNOQi6iwvI+ibIcnKinp0HEP9nDgTNyil8/J+xodHERwPg==",
+      "version": "0.32.17",
+      "resolved": "https://registry.npmjs.org/phonic/-/phonic-0.32.17.tgz",
+      "integrity": "sha512-qpGrWFyOlkn8OCzU09M3Ysg6eQiggEFj8Wgh9vhyAA7bIwBAWZfhDZq91EgPZaxH7wTJDgccRuVTfa7Cpt3dhw==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.20.0"

--- a/06-conversation-browser/node/package.json
+++ b/06-conversation-browser/node/package.json
@@ -13,7 +13,7 @@
     "dotenv": "16.5.0",
     "hls.js": "1.6.18",
     "hono": "4.8.5",
-    "phonic": "0.32.9",
+    "phonic": "0.32.17",
     "tsx": "4.20.3"
   },
   "devDependencies": {


### PR DESCRIPTION
**Draft — blocked on an SDK release. Do not merge yet.** See "Before this can merge" below.

## Why

The example minted a session token that could stream **every live conversation in the workspace** and handed it to the browser. A user could read it out of devtools, change the conversation ID in the URL, and listen to a call that wasn't theirs. A customer hit exactly this, which is what prompted Phonic-Co/phonic-api#1235 and #1238.

## What changed

- `POST /session-token` now takes a `conversation_id` and mints the token with `conversation_ids: [conversationId]`, so it covers only the conversation being previewed.
- The browser sends the conversation ID when requesting the token.
- A 400 from that route is surfaced in the UI instead of leaving the page stuck on "Creating a short-lived session…", and the error body matches the `{error: {message}}` shape the Phonic API itself returns.
- README gains a "Before you copy this into production" section.

## What the example still leaves to the reader — deliberately

Called out in the README rather than silently omitted, because this is sample code people paste into production:

1. **Authorizing the request.** `POST /session-token` here mints for any caller. Phonic enforces *which* conversation a token may read; only the integrator knows *whose* it is.
2. **Keeping the token off the browser entirely.** The local server already proxies the HLS requests, so a stricter version attaches the token server-side and proxies the WebSocket too, and the browser never holds a Phonic credential.

## Before this can merge

1. Phonic-Co/fern-config#175 merges (adds `conversation_ids` to the OpenAPI spec).
2. That auto-opens SDK PRs in `phonic-node` / `phonic-python`; merging those publishes new packages.
3. **This PR then needs `package.json` bumped** off `phonic@0.32.9` to the release carrying the field.

Until step 3, `conversation_ids` is not on `CreateSessionTokenRequest` and `npm run ct` fails here. That is expected, not an oversight.

Also worth noting the API change is breaking for the live WebSocket payload: session tokens now receive only the conversation's own content, not the agent's configuration. The README documents the exact field list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bd171fb0230612176ebe266549649a2419125aff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->